### PR TITLE
UI performance tests under engagement

### DIFF
--- a/api/v1/test.py
+++ b/api/v1/test.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from flask import request
 from flask_restful import Resource
+from pylon.core.tools import log
 
 from ...models.pd.test_parameters import UITestParams, UITestParam
 from ...models.ui_tests import UIPerformanceTest
@@ -82,7 +83,11 @@ class API(Resource):
         """ Run test with possible overridden params """
         config_only_flag = request.json.pop('type', False)
         execution_flag = request.json.pop('execution', True)
+        engagement_id = request.json.get('integrations', {}).get('reporters', {})\
+            .get('reporter_engagement', {}).get('id')
+        
         purpose = 'run'
+
         if 'params' in request.json:
             purpose = 'control_tower'
             request.json['test_parameters'] = request.json.pop('params')
@@ -119,9 +124,9 @@ class API(Resource):
 
         if config_only_flag == '_test':
             return {
-                       'test': test.to_json(),
-                       'config': run_test(test, config_only=True, execution=execution_flag),
-                       'api_json': test.api_json(),
+                    'test': test.to_json(),
+                    'config': run_test(test, config_only=True, execution=execution_flag),
+                    'api_json': test.api_json(),
                    }, 200
-        resp = run_test(test, config_only=config_only_flag, execution=execution_flag)
+        resp = run_test(test, config_only=config_only_flag, execution=execution_flag, engagement_id=engagement_id)
         return resp, resp.get('code', 200)

--- a/api/v1/tests.py
+++ b/api/v1/tests.py
@@ -68,6 +68,10 @@ class API(Resource):
         Create test and run on demand
         """
         run_test_ = request.json.pop('run_test', False)
+        engagement_id = request.json.get('integrations', {}).get('reporters', {})\
+            .get('reporter_engagement', {}).get('id')
+
+
         test_data, errors = parse_test_data(
             project_id=project_id,
             request_data=request.json,
@@ -106,6 +110,6 @@ class API(Resource):
         test.handle_change_schedules(schedules)
 
         if run_test_:
-            resp = run_test(test)
+            resp = run_test(test, engagement_id=engagement_id)
             return resp, resp.get('code', 200)
         return test.api_json(), 200

--- a/models/ui_report.py
+++ b/models/ui_report.py
@@ -45,6 +45,9 @@ class UIReport(db_tools.AbstractBaseMixin, db.Base, rpc_tools.RpcMixin):
     time_to_first_paint = Column(JSON, unique=False, nullable=True)
     load_time = Column(JSON, unique=False, nullable=True)
     total_blocking_time = Column(JSON, unique=False, nullable=True)
+    
+    #engagement id
+    engagement = Column(String(64), nullable=True, default=None)
 
     # def insert(self):
     #     if not self.test_config:

--- a/slots/core.py
+++ b/slots/core.py
@@ -9,7 +9,10 @@ class Slot:  # pylint: disable=E1101,R0903
     def content(self, context, slot, payload):
         project_id = context.rpc_manager.call.project_get_id()
         public_regions = context.rpc_manager.call.get_rabbit_queues("carrier")
-        public_regions.remove("__internal")
+        try:
+            public_regions.remove("__internal")
+        except:
+            pass
         project_regions = context.rpc_manager.call.get_rabbit_queues(f"project_{project_id}_vhost")
         cloud_regions = context.rpc_manager.timeout(3).integrations_get_cloud_integrations(
             project_id)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -16,9 +16,8 @@ def test_parameter_value_by_name(test_parameters: List[dict], param_name: str) -
             return i['default']
 
 
-def run_test(test: 'UIPerformanceTest', config_only: bool = False, execution: bool = False) -> dict:
+def run_test(test: 'UIPerformanceTest', config_only: bool = False, execution: bool = False, engagement_id: str = None) -> dict:
     event = test.configure_execution_json(execution=execution)
-
     if config_only:
         return event
 
@@ -36,7 +35,8 @@ def run_test(test: 'UIPerformanceTest', config_only: bool = False, execution: bo
         loops=test.loops,
         aggregation=test.aggregation,
         test_config=test.api_json(),
-        test_uid=test.test_uid
+        test_uid=test.test_uid,
+        engagement=engagement_id
     )
     report.insert()
     event["cc_env_vars"]["REPORT_ID"] = str(report.uid)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -91,7 +91,7 @@ def parse_test_data(project_id: int, request_data: dict,
     errors = list()
 
     common_params = request_data.pop('common_params', {})
-    cloud_settings = common_params['env_vars']['cloud_settings']
+    cloud_settings = common_params.get('env_vars', {}).get('cloud_settings')
 
     if cloud_settings:
         integration_name = cloud_settings.get("integration_name")


### PR DESCRIPTION
Changes:

1. Engagement field is added to the test report model
2. Api endpoints that start tests changed in the way that they are accepting engagement_id now
3. run_tests methods changed to include engagement_id value into report table 